### PR TITLE
Add repository_dispatch trigger for cross-repo updates

### DIFF
--- a/.github/workflows/update-stats.yml
+++ b/.github/workflows/update-stats.yml
@@ -13,6 +13,10 @@ on:
         type: boolean
         default: true
 
+  # Triggered by sysartifacts/secartifacts repos when results or organizers change
+  repository_dispatch:
+    types: [source-data-updated]
+
 permissions:
   contents: write
   packages: write
@@ -96,8 +100,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}
         run: |
           REFRESH_FLAG=""
-          # Scheduled runs always refresh; manual runs use the input toggle
-          if [[ "${{ github.event_name }}" == "schedule" ]] || [[ "${{ inputs.refresh_repo_stats }}" == "true" ]]; then
+          # Scheduled runs always refresh; dispatch/manual runs use the input toggle
+          if [[ "${{ github.event_name }}" == "schedule" ]] || [[ "${{ github.event_name }}" == "repository_dispatch" ]] || [[ "${{ inputs.refresh_repo_stats }}" == "true" ]]; then
             REFRESH_FLAG="--refresh"
           fi
           cd reprodb-pipeline


### PR DESCRIPTION
Adds a `repository_dispatch` trigger (`source-data-updated` event type) to the update-stats workflow so that sysartifacts and secartifacts can automatically kick off a pipeline run when they push changes to `results.md` or `organizers.md` files.

**Companion PRs:**
- sysartifacts/sysartifacts.github.io#178
- secartifacts/secartifacts.github.io#148

Those PRs add a `notify-reprodb.yml` workflow that sends the dispatch event using a `REPRODB_DISPATCH_TOKEN` secret (already configured in both repos).