### PR TITLE
fix: website root discovery for conference page auto-creation

### DIFF
--- a/src/models/artifacts/artifacts.py
+++ b/src/models/artifacts/artifacts.py
@@ -9,32 +9,14 @@ from typing import Literal
 
 from pydantic import BaseModel, Field, field_validator
 
-CONFERENCE_NAMES = Literal[
-    "ACSAC",
-    "ATC",
-    "CAIS",
-    "CHES",
-    "EUROSYS",
-    "FAST",
-    "NDSS",
-    "OSDI",
-    "PETS",
-    "SC",
-    "SOSP",
-    "SYSTEX",
-    "USENIXSEC",
-    "VEHICLESEC",
-    "WOOT",
-]
-
 CATEGORY = Literal["systems", "security"]
 
 
 class Artifact(BaseModel):
     """A single research artifact associated with a conference paper."""
 
-    conference: CONFERENCE_NAMES = Field(
-        description="Conference abbreviation, e.g. 'OSDI', 'USENIXSEC', 'NDSS'. See CONFERENCE_NAMES for the full list.",
+    conference: str = Field(
+        description="Conference abbreviation, e.g. 'OSDI', 'USENIXSEC', 'NDSS'. Discovered dynamically from sys/secartifacts folder structure.",
         examples=["OSDI"],
     )
     category: CATEGORY = Field(

--- a/src/scrapers/repo_utils.py
+++ b/src/scrapers/repo_utils.py
@@ -51,6 +51,7 @@ def _load_known_dead_hosts() -> set[str]:
 
 
 CACHE_TTL = _SECONDS_PER_DAY * 30  # 30 days – conference listings & raw file downloads
+CACHE_TTL_RESULTS = _SECONDS_PER_DAY * 1  # 1 day – results/committee files (change frequently)
 CACHE_TTL_URL = _SECONDS_PER_DAY * 90  # 90 days – URL existence checks (positive)
 CACHE_TTL_URL_NEG = _SECONDS_PER_DAY * 7  # 7 days  – URL non-existence checks (re-check weekly)
 CACHE_TTL_STATS = _SECONDS_PER_DAY * 30  # 30 days – GitHub/Zenodo/Figshare stats
@@ -82,8 +83,8 @@ github_urls = {
         "api_url": "https://api.github.com/repos/sysartifacts/sysartifacts.github.io/contents/_conferences/",
     },
     "sec": {
-        "base_url": "https://github.com/secartifacts/secartifacts.github.io/blob/master/_conferences/",
-        "raw_base_url": "https://raw.githubusercontent.com/secartifacts/secartifacts.github.io/master/_conferences/",
+        "base_url": "https://github.com/secartifacts/secartifacts.github.io/blob/main/_conferences/",
+        "raw_base_url": "https://raw.githubusercontent.com/secartifacts/secartifacts.github.io/main/_conferences/",
         "api_url": "https://api.github.com/repos/secartifacts/secartifacts.github.io/contents/_conferences/",
     },
 }
@@ -482,12 +483,21 @@ def _cached_get(url):
 
     For GitHub API URLs, sends If-None-Match so that 304 responses are free
     (do not count against rate limits).
+
+    Conference directory listings and results/committee files use a short TTL
+    (1 day) so new conferences are picked up quickly.
     """
-    cached = _read_cache(CACHE_DIR, url, ttl=CACHE_TTL, namespace="http_get")
+    # Use shorter TTL for content that changes when new conferences/results are added
+    is_github_api = "api.github.com" in url
+    is_content_url = "raw.githubusercontent.com" in url and (
+        "/results.md" in url or "/result.md" in url or "/committee.md" in url or "/organizers.md" in url
+    )
+    ttl = CACHE_TTL_RESULTS if (is_github_api or is_content_url) else CACHE_TTL
+
+    cached = _read_cache(CACHE_DIR, url, ttl=ttl, namespace="http_get")
     if cached is not _MISSING:
         return cached
 
-    is_github_api = "api.github.com" in url
     headers = _github_headers() if is_github_api else {}
 
     # Use stored ETag for conditional request if available

--- a/src/utils/normalization/conference.py
+++ b/src/utils/normalization/conference.py
@@ -81,7 +81,7 @@ def discover_conferences(website_root: str | None = None) -> tuple[frozenset[str
 
 # Built-in fallbacks (kept in sync by CI; only used when website is absent).
 _FALLBACK_SYSTEMS = frozenset({"ATC", "CAIS", "EUROSYS", "FAST", "OSDI", "SC", "SOSP"})
-_FALLBACK_SECURITY = frozenset({"ACSAC", "CHES", "NDSS", "PETS", "SYSTEX", "USENIXSEC", "VEHICLESEC", "WOOT"})
+_FALLBACK_SECURITY = frozenset({"ACSAC", "CHES", "NDSS", "PETS", "SP", "SYSTEX", "USENIXSEC", "VEHICLESEC", "WOOT"})
 
 # Module-level sets, populated on first import.
 SYSTEMS_CONFS, SECURITY_CONFS = discover_conferences()
@@ -197,6 +197,7 @@ CONF_DISPLAY_NAMES: dict[str, str] = {
     "NDSS": "NDSS",
     "SYSTEX": "SysTEX",
     "USENIXSEC": "USENIX Security",
+    "SP": "IEEE S&P",
     "VEHICLESEC": "USENIX VehicleSec",
 }
 

--- a/src/utils/normalization/conference.py
+++ b/src/utils/normalization/conference.py
@@ -45,9 +45,19 @@ def _scan_area_confs(website_root: str, area: str) -> frozenset[str]:
 
 
 def _find_website_root() -> str | None:
-    """Try to locate the website repo relative to the pipeline."""
-    # Common locations when running from reprodb-pipeline/
-    for candidate in ("../reprodb.github.io", "reprodb.github.io"):
+    """Try to locate the website repo relative to the pipeline.
+
+    The website content lives under ``{repo}/src/content/`` (Jekyll source).
+    We return the path that contains ``content/systems/``.
+    """
+    for candidate in (
+        "../reprodb.github.io/src",
+        "../website/src",
+        "reprodb.github.io/src",
+        "../reprodb.github.io",
+        "../website",
+        "reprodb.github.io",
+    ):
         if os.path.isdir(os.path.join(candidate, "content", "systems")):
             return candidate
     return None


### PR DESCRIPTION
Follow-up to #10.

`_find_website_root()` only looked for `content/systems/` directly under the repo root, but the website uses `src/content/systems/`. This caused `ensure_conference_pages` to silently skip page creation for new conferences (SP, VehicleSec, CAIS).

Now searches for:
- `../reprodb.github.io/src` (local dev)
- `../website/src` (CI checkout)
- `reprodb.github.io/src`
- Legacy paths without `src/` for backward compat