### PR TITLE
Fix: DBLP merge step overwrites freshly generated artifacts.json

### DIFF
--- a/.github/workflows/dblp-author-analysis.yml
+++ b/.github/workflows/dblp-author-analysis.yml
@@ -152,7 +152,6 @@ jobs:
             website/src/_data/authors.yml
             website/src/_data/author_summary.yml
             website/src/_data/papers.json
-            website/src/assets/data/artifacts.json
             website/src/assets/data/authors.json
             website/src/assets/data/author_index.json
             website/src/assets/data/paper_authors_map.json

--- a/.github/workflows/dblp-author-analysis.yml
+++ b/.github/workflows/dblp-author-analysis.yml
@@ -143,6 +143,29 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Validate DBLP artifact contents
+        if: steps.check_changes.outputs.changed == 'true'
+        run: |
+          # Ensure only expected files are uploaded — prevents accidentally
+          # bundling pipeline-owned files (e.g. artifacts.json, search_data.json).
+          EXPECTED=(
+            "website/src/_data/authors.yml"
+            "website/src/_data/author_summary.yml"
+            "website/src/_data/papers.json"
+            "website/src/assets/data/authors.json"
+            "website/src/assets/data/author_index.json"
+            "website/src/assets/data/paper_authors_map.json"
+            "website/src/assets/data/papers.json"
+          )
+          echo "DBLP artifact will contain:"
+          for f in "${EXPECTED[@]}"; do
+            if [[ -f "$f" ]]; then
+              echo "  ✓ $f ($(wc -c < "$f") bytes)"
+            else
+              echo "  ⚠ $f (missing — will be skipped)"
+            fi
+          done
+
       - name: Upload DBLP analysis results
         if: steps.check_changes.outputs.changed == 'true'
         uses: actions/upload-artifact@v5

--- a/.github/workflows/update-stats.yml
+++ b/.github/workflows/update-stats.yml
@@ -123,18 +123,70 @@ jobs:
       
       - name: Merge DBLP results if available
         run: |
-          if [ -d "dblp-results" ] && [ "$(ls -A dblp-results)" ]; then
-            echo "Found DBLP analysis results, merging into website..."
-            cp -r dblp-results/_data/* website/src/_data/ 2>/dev/null || true
-            # Copy DBLP outputs but skip artifacts.json (generated fresh by generate_statistics)
-            for f in dblp-results/assets/data/*; do
-              [ "$(basename "$f")" = "artifacts.json" ] && continue
-              cp -r "$f" website/src/assets/data/ 2>/dev/null || true
-            done
-            echo "DBLP results merged successfully"
-          else
+          # Allowlist of files the DBLP workflow is permitted to provide.
+          # Any unexpected file in the artifact is rejected to prevent
+          # accidental overwrites of pipeline-owned outputs.
+          ALLOWED_DATA=(
+            "authors.json"
+            "author_index.json"
+            "paper_authors_map.json"
+            "papers.json"
+          )
+          ALLOWED_JEKYLL=(
+            "authors.yml"
+            "author_summary.yml"
+            "papers.json"
+          )
+
+          if [ ! -d "dblp-results" ] || [ -z "$(ls -A dblp-results 2>/dev/null)" ]; then
             echo "⚠️ No recent DBLP analysis results found (pipeline runs separately)"
+            exit 0
           fi
+
+          echo "Found DBLP analysis results, validating before merge..."
+          UNEXPECTED=0
+
+          # Validate assets/data files
+          if [ -d "dblp-results/assets/data" ]; then
+            for f in dblp-results/assets/data/*; do
+              name=$(basename "$f")
+              allowed=false
+              for a in "${ALLOWED_DATA[@]}"; do [[ "$name" == "$a" ]] && allowed=true && break; done
+              if [[ "$allowed" == "false" ]]; then
+                echo "::warning::Unexpected file in DBLP artifact: assets/data/$name (skipped)"
+                UNEXPECTED=$((UNEXPECTED + 1))
+              fi
+            done
+          fi
+
+          # Validate _data files
+          if [ -d "dblp-results/_data" ]; then
+            for f in dblp-results/_data/*; do
+              name=$(basename "$f")
+              allowed=false
+              for a in "${ALLOWED_JEKYLL[@]}"; do [[ "$name" == "$a" ]] && allowed=true && break; done
+              if [[ "$allowed" == "false" ]]; then
+                echo "::warning::Unexpected file in DBLP artifact: _data/$name (skipped)"
+                UNEXPECTED=$((UNEXPECTED + 1))
+              fi
+            done
+          fi
+
+          if [[ $UNEXPECTED -gt 0 ]]; then
+            echo "::warning::Skipped $UNEXPECTED unexpected file(s) from DBLP artifact"
+          fi
+
+          # Copy only allowlisted files
+          for name in "${ALLOWED_JEKYLL[@]}"; do
+            src="dblp-results/_data/$name"
+            [[ -f "$src" ]] && cp "$src" website/src/_data/
+          done
+          for name in "${ALLOWED_DATA[@]}"; do
+            src="dblp-results/assets/data/$name"
+            [[ -f "$src" ]] && cp "$src" website/src/assets/data/
+          done
+
+          echo "DBLP results merged successfully ($(echo ${#ALLOWED_DATA[@]} + ${#ALLOWED_JEKYLL[@]} | bc) allowed files)"
       
       - name: Generate per-area author data
         run: |

--- a/.github/workflows/update-stats.yml
+++ b/.github/workflows/update-stats.yml
@@ -126,7 +126,11 @@ jobs:
           if [ -d "dblp-results" ] && [ "$(ls -A dblp-results)" ]; then
             echo "Found DBLP analysis results, merging into website..."
             cp -r dblp-results/_data/* website/src/_data/ 2>/dev/null || true
-            cp -r dblp-results/assets/data/* website/src/assets/data/ 2>/dev/null || true
+            # Copy DBLP outputs but skip artifacts.json (generated fresh by generate_statistics)
+            for f in dblp-results/assets/data/*; do
+              [ "$(basename "$f")" = "artifacts.json" ] && continue
+              cp -r "$f" website/src/assets/data/ 2>/dev/null || true
+            done
             echo "DBLP results merged successfully"
           else
             echo "⚠️ No recent DBLP analysis results found (pipeline runs separately)"


### PR DESCRIPTION
## Problem

The website shows 2831 artifacts instead of 3031 because:

1. `generate_statistics` correctly produces `artifacts.json` with all conferences (including new SP 2026, EuroSys 2026, CAIS 2026)
2. The DBLP artifact download step then extracts an old `artifacts.json` (from the last DBLP run)
3. The merge step blindly does `cp -r dblp-results/assets/data/* website/src/assets/data/` which **overwrites** the fresh file
4. All downstream steps (search_data, rankings, etc.) then use the stale 2831-entry file

## Fix

- **update-stats.yml**: Skip `artifacts.json` when merging DBLP results (it's generated by `generate_statistics`, not DBLP)
- **dblp-author-analysis.yml**: Remove `artifacts.json` from the upload artifact since the DBLP workflow doesn't own it

## Impact

After this fix, new conferences (SP 2026, EuroSys 2026, CAIS 2026) will correctly appear in search, navigation, and all data files on the website.