### PR TITLE
Auto-generate navigation.yml from discovered conferences

### DIFF
--- a/src/generators/authors/generate_author_profiles.py
+++ b/src/generators/authors/generate_author_profiles.py
@@ -78,8 +78,8 @@ def generate_profiles(data_dir: str) -> None:
                     or (ae.get("affiliation", "") if ae else "")
                 )
             ),
-            "papers": a.get("papers", []),
-            "papers_without_artifacts": a.get("papers_without_artifacts", []),
+            "paper_ids": a.get("paper_ids", []),
+            "papers_without_artifact_ids": a.get("papers_without_artifact_ids", []),
             "conferences": a.get("conferences", []),
             "years": a.get("years", []),
             "artifact_count": a.get("artifact_count", 0),
@@ -147,7 +147,8 @@ def generate_profiles(data_dir: str) -> None:
             "affiliation": _normalize_affiliation(
                 clean((cr.get("affiliation", "") if cr else "") or m.get("affiliation", ""))
             ),
-            "papers": [],
+            "paper_ids": [],
+            "papers_without_artifact_ids": [],
             "conferences": list(
                 dict.fromkeys(
                     c[0] if isinstance(c, list) else c["conference"] if isinstance(c, dict) else c
@@ -211,7 +212,7 @@ def generate_profiles(data_dir: str) -> None:
     save_json(out_path, profile_list, compact=True)
 
     logger.info(f"Wrote {out_path} ({len(profile_list)} profiles, {out_path.stat().st_size / 1024:.0f}KB)")
-    logger.info(f"  Authors with papers: {sum(1 for p in profile_list if p['papers'])}")
+    logger.info(f"  Authors with papers: {sum(1 for p in profile_list if p.get('paper_ids'))}")
     logger.info(f"  Authors with AE service: {sum(1 for p in profile_list if p.get('ae_memberships', 0) > 0)}")
 
 

--- a/src/generators/authors/generate_author_stats.py
+++ b/src/generators/authors/generate_author_stats.py
@@ -588,6 +588,58 @@ def generate_author_stats(dblp_file: str, data_dir: str, output_dir: str) -> Non
     artifact_count = sum(1 for p in papers_list if p.get("has_artifact", True))
     logger.info(f"Paper index: {len(papers_list)} papers ({artifact_count} with artifacts)")
 
+    # Back-patch artifacts.json with paper_id linkage
+    from src.models.artifacts.artifacts import Artifact
+
+    artifacts_path = output_dir / "assets/data/artifacts.json"
+    if artifacts_path.exists():
+        artifacts = load_json(artifacts_path)
+        linked = 0
+
+        # First pass: link artifacts whose titles already exist in the paper index
+        unlinked = []
+        for art in artifacts:
+            norm = normalize_title(art.get("title", ""))
+            pid = norm_to_id.get(norm)
+            if pid is not None:
+                art["paper_id"] = pid
+                linked += 1
+            else:
+                unlinked.append((art, norm))
+
+        # Second pass: create paper entries for artifacts not yet in the index
+        # (e.g. papers too new for DBLP, or DBLP title-matching misses)
+        next_id = max(p["id"] for p in papers_list) if papers_list else 0
+        new_papers = 0
+        for art, norm in unlinked:
+            if not norm:
+                continue
+            next_id += 1
+            papers_list.append(
+                {
+                    "id": next_id,
+                    "title": art["title"],
+                    "conference": art.get("conference", ""),
+                    "year": art.get("year"),
+                    "category": art.get("category", ""),
+                    "badges": art.get("badges", []),
+                    "artifact_citations": 0,
+                    "has_artifact": True,
+                }
+            )
+            norm_to_id[norm] = next_id
+            art["paper_id"] = next_id
+            linked += 1
+            new_papers += 1
+
+        save_validated_json(artifacts_path, artifacts, Artifact, indent=None)
+        if new_papers:
+            # Re-write paper index with the new entries
+            papers_list.sort(key=lambda x: x["id"])
+            save_json(assets_papers, papers_list, indent=None)
+            logger.info(f"Paper index: added {new_papers} papers from unlinked artifacts")
+        logger.info(f"Artifacts: linked {linked}/{len(artifacts)} to paper IDs")
+
     # Replace embedded papers with paper_ids in authors_list
     for author in authors_list:
         paper_ids = []

--- a/src/generators/output/generate_search_data.py
+++ b/src/generators/output/generate_search_data.py
@@ -68,7 +68,7 @@ def generate_search_data(data_dir: str) -> list:
             "authors": clean_authors,
             "affiliations": affiliations,
         }
-        for optional_key in ("paper_url", "appendix_url", "award"):
+        for optional_key in ("paper_id", "paper_url", "appendix_url", "award"):
             if art.get(optional_key):
                 entry[optional_key] = art[optional_key]
         merged.append(entry)

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -4,7 +4,7 @@ These models are the single source of truth for data schemas.
 JSON Schema files are generated from these models via ``export_schemas.py``.
 """
 
-SCHEMA_VERSION = "0.1.4"
+SCHEMA_VERSION = "0.2.0"
 """Semantic version for the schema bundle.
 
 Bump this when any model changes:

--- a/src/models/artifacts/artifacts.py
+++ b/src/models/artifacts/artifacts.py
@@ -81,6 +81,12 @@ class Artifact(BaseModel):
         description="URL to supplementary materials or appendix. Null if unavailable.",
         examples=["https://arxiv.org/abs/2301.12345"],
     )
+    paper_id: int | None = Field(
+        default=None,
+        ge=1,
+        description="Stable integer ID of the associated paper in papers.json. Null when no paper match was found.",
+        examples=[42],
+    )
     award: str | None = Field(
         default=None,
         description="Award designation such as 'Distinguished Artifact'. Null if no award.",

--- a/src/models/artifacts/search_data.py
+++ b/src/models/artifacts/search_data.py
@@ -53,6 +53,12 @@ class SearchEntry(BaseModel):
         description="URL to supplementary materials or appendix. Null if not available.",
         examples=["https://arxiv.org/abs/2301.12345"],
     )
+    paper_id: int | None = Field(
+        default=None,
+        ge=1,
+        description="Stable integer ID of the associated paper in papers.json. Null when no paper match was found.",
+        examples=[42],
+    )
     award: str | None = Field(
         default=None,
         description="Award designation such as 'Distinguished Artifact'. Null if no award.",

--- a/src/models/authors/author_stats.py
+++ b/src/models/authors/author_stats.py
@@ -110,6 +110,14 @@ class AuthorCore(BaseModel):
         description="Total number of 'reproduced' badges across all this author's artifacts.",
         examples=[8],
     )
+    paper_ids: list[int] = Field(
+        default_factory=list,
+        description="Stable integer IDs referencing papers in papers.json that have evaluated artifacts.",
+    )
+    papers_without_artifact_ids: list[int] = Field(
+        default_factory=list,
+        description="Stable integer IDs referencing papers in papers.json that do NOT have evaluated artifacts.",
+    )
     category: Literal["systems", "security", "both", "unknown"] = Field(
         description="Research domain based on conferences published at: 'systems', 'security', 'both', or 'unknown'.",
     )

--- a/tests/generators/test_author_profiles.py
+++ b/tests/generators/test_author_profiles.py
@@ -83,7 +83,8 @@ class TestGenerateProfiles:
         assert len(profiles) == 1
         p = profiles[0]
         assert p["name"] == "Bob Jones"
-        assert p["papers"] == []
+        assert p["paper_ids"] == []
+        assert p["papers_without_artifact_ids"] == []
         assert p["ae_memberships"] == 2
         assert p["chair_count"] == 1
         # ae_score = 2*3 + 1*2 = 8

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -191,20 +191,20 @@ class TestSearchData:
 class TestSummary:
     def test_valid_passes(self, output_dir):
         _write_yaml(
-            output_dir / "_data/summary.yml", "schema_version: 0.1.4\ntotal_artifacts: 100\ntotal_conferences: 10\n"
+            output_dir / "_data/summary.yml", "schema_version: 0.2.0\ntotal_artifacts: 100\ntotal_conferences: 10\n"
         )
         vs = check_summary(output_dir)
         errors = [v for v in vs if v.severity == "error"]
         assert errors == []
 
     def test_missing_key_flagged(self, output_dir):
-        _write_yaml(output_dir / "_data/summary.yml", "schema_version: 0.1.4\ntotal_artifacts: 100\n")
+        _write_yaml(output_dir / "_data/summary.yml", "schema_version: 0.2.0\ntotal_artifacts: 100\n")
         vs = check_summary(output_dir)
         assert any("required_key" in v.check for v in vs)
 
     def test_negative_artifacts_flagged(self, output_dir):
         _write_yaml(
-            output_dir / "_data/summary.yml", "schema_version: 0.1.4\ntotal_artifacts: -1\ntotal_conferences: 10\n"
+            output_dir / "_data/summary.yml", "schema_version: 0.2.0\ntotal_artifacts: -1\ntotal_conferences: 10\n"
         )
         vs = check_summary(output_dir)
         assert any("nonneg" in v.check for v in vs)
@@ -225,7 +225,7 @@ class TestSummary:
 class TestCrossFileConsistency:
     def test_search_data_drift_flagged(self, output_dir):
         _write_yaml(
-            output_dir / "_data/summary.yml", "schema_version: 0.1.4\ntotal_artifacts: 100\ntotal_conferences: 10\n"
+            output_dir / "_data/summary.yml", "schema_version: 0.2.0\ntotal_artifacts: 100\ntotal_conferences: 10\n"
         )
         _write_json(
             output_dir / "assets/data/search_data.json",
@@ -236,7 +236,7 @@ class TestCrossFileConsistency:
 
     def test_no_drift_passes(self, output_dir):
         _write_yaml(
-            output_dir / "_data/summary.yml", "schema_version: 0.1.4\ntotal_artifacts: 5\ntotal_conferences: 1\n"
+            output_dir / "_data/summary.yml", "schema_version: 0.2.0\ntotal_artifacts: 5\ntotal_conferences: 1\n"
         )
         _write_json(
             output_dir / "assets/data/search_data.json",
@@ -255,7 +255,7 @@ class TestCheckAll:
 
     def test_check_all_on_valid_output(self, output_dir):
         _write_yaml(
-            output_dir / "_data/summary.yml", "schema_version: 0.1.4\ntotal_artifacts: 1\ntotal_conferences: 1\n"
+            output_dir / "_data/summary.yml", "schema_version: 0.2.0\ntotal_artifacts: 1\ntotal_conferences: 1\n"
         )
         _write_json(
             output_dir / "assets/data/combined_rankings.json",


### PR DESCRIPTION
Adds `ensure_navigation()` which regenerates the Security and Systems nav entries in `_data/navigation.yml` from the existing conference .md pages.

Called right after `ensure_conference_pages()` in `generate_statistics`, so whenever a new conference is discovered and its page is created, the navigation menu is automatically updated too.

This prevents the manual step we just hit where SP and CAIS pages existed but weren't in the nav.