### PR TITLE
Add IEEE S&P committee scraper

### DIFF
--- a/data/local_committees.yaml
+++ b/data/local_committees.yaml
@@ -2696,3 +2696,334 @@ woot2026:
 - affiliation: EPFL
   name: Eduard Vlad
   role: member
+sp2026:
+- name: Jelena Mirkovic
+  affiliation: University of Southern California
+  role: chair
+- name: Manuel Egele
+  affiliation: Boston University
+  role: chair
+- name: David Adei
+  affiliation: North Carolina State University
+  role: member
+- name: Mutahar Ali
+  affiliation: University of California Irvine
+  role: member
+- name: Juyang Bai
+  affiliation: John Hopkins University
+  role: member
+- name: Kaustav Bhattacharjee
+  affiliation: Pacific Northwest National Laboratory
+  role: member
+- name: Evangelos Bitsikas
+  affiliation: Northeastern University
+  role: member
+- name: Noah Brown
+  affiliation: UNC Chapel Hill
+  role: member
+- name: Quinn Burke
+  affiliation: University of Wisconsin-Madison
+  role: member
+- name: Arifa Islam Champa
+  affiliation: Idaho State University
+  role: member
+- name: Janak Chandarana
+  affiliation: Amazon
+  role: member
+- name: Xiang Chen
+  affiliation: The Hong Kong University of Science and Technology
+  role: member
+- name: Yanju Chen
+  affiliation: University of California San Diego
+  role: member
+- name: Phaedra Curlin
+  affiliation: University of Colorado Boulder
+  role: member
+- name: Aritra Dasgupta
+  affiliation: University of Florida
+  role: member
+- name: Sohom Datta
+  affiliation: North Carolina State University
+  role: member
+- name: Dipsy Desai
+  affiliation: University of Southern California
+  role: member
+- name: Kyle Domico
+  affiliation: University of Wisconsin-Madison
+  role: member
+- name: Zachary Espiritu
+  affiliation: MongoDB Research
+  role: member
+- name: Marius Fleischer
+  affiliation: NVIDIA
+  role: member
+- name: Saber Ganjisaffar
+  affiliation: University of California Riverside
+  role: member
+- name: Yuanjun Gong
+  affiliation: University of Trento
+  role: member
+- name: Vaishnavi Gudur
+  affiliation: Microsoft
+  role: member
+- name: Wanda Guo
+  affiliation: Texas A&M University
+  role: member
+- name: Mona Hashemi
+  affiliation: National University of Singapore
+  role: member
+- name: Yujin Huang
+  affiliation: The University of Melbourne
+  role: member
+- name: Michele Ianni
+  affiliation: University of Calabria
+  role: member
+- name: Abdullah Al Ishtiaq
+  affiliation: The Pennsylvania State University
+  role: member
+- name: Felix Klement
+  affiliation: University of Passau
+  role: member
+- name: Wei Kong
+  affiliation: Zhejiang Sci-tech University
+  role: member
+- name: Jinseo Lee
+  affiliation: KAIST
+  role: member
+- name: Kunyang Li
+  affiliation: University of Wisconsin-Madison
+  role: member
+- name: Haodong Li
+  affiliation: HUST
+  role: member
+- name: Xin Liu
+  affiliation: Florida State University
+  role: member
+- name: Puzhuo Liu
+  affiliation: Ant Group & Tsinghua University
+  role: member
+- name: Mingyi Liu
+  affiliation: Georgia Institute of Technology
+  role: member
+- name: Tim Hsuan-Ting Lu
+  affiliation: University of Wisconsin-Madison
+  role: member
+- name: Jie Ma
+  affiliation: Beihang University
+  role: member
+- name: Aleksandr Nahapetyan
+  affiliation: North Carolina State University
+  role: member
+- name: Kevin Nam
+  affiliation: Seoul National University
+  role: member
+- name: Tushar Nayan
+  affiliation: Florida International University
+  role: member
+- name: Jean-Charles Noirot Ferrand
+  affiliation: University of Wisconsin-Madison
+  role: member
+- name: Aaryan Patel
+  affiliation: University of Wisconsin-Madison
+  role: member
+- name: Huiyun Peng
+  affiliation: Purdue University
+  role: member
+- name: Mirza Masfiqur Rahman
+  affiliation: Purdue University
+  role: member
+- name: Ali Ranjbar
+  affiliation: Pennsylvania State University
+  role: member
+- name: Andrew Roberts
+  affiliation: KTH Royal Institute of Technology
+  role: member
+- name: Arul Thileeban Sagayam
+  affiliation: Bloomberg
+  role: member
+- name: Ashfaq Ali Shafin
+  affiliation: Florida International University
+  role: member
+- name: Jade Sheffey
+  affiliation: University of Massachusetts Amherst
+  role: member
+- name: Leming Shen
+  affiliation: The Hong Kong Polytechnic University
+  role: member
+- name: Sachin Shukla
+  affiliation: Microsoft
+  role: member
+- name: Salvatore Signorello
+  affiliation: Nova University Lisbon
+  role: member
+- name: Amit Singha
+  affiliation: Purdue University
+  role: member
+- name: Tong Sun
+  affiliation: Zhejiang University
+  role: member
+- name: Daan Vansteenhuyse
+  affiliation: DistriNet, KU Leuven
+  role: member
+- name: Hulin Wang
+  affiliation: Arizona State University
+  role: member
+- name: Anjiang Wei
+  affiliation: Stanford University
+  role: member
+- name: Liwen Xu
+  affiliation: ETH Zürich
+  role: member
+- name: Dianshi Yang
+  affiliation: University of Delaware
+  role: member
+- name: Tao Yang
+  affiliation: KAUST
+  role: member
+- name: Mingming Zha
+  affiliation: Indiana University Bloomington
+  role: member
+- name: Guangsheng Zhang
+  affiliation: University of Technology Sydney
+  role: member
+- name: Olawale Akanji
+  affiliation: Boston University, USA
+  role: member
+- name: Eyhab Al-Masri
+  affiliation: University of Washington, USA
+  role: member
+- name: Weiheng Bai
+  affiliation: University of Minnesota, USA
+  role: member
+- name: Andrew Bao
+  affiliation: University of Minnesota, USA
+  role: member
+- name: Yifeng Cai
+  affiliation: Peking University, China
+  role: member
+- name: Sine Canbolat Kaya
+  affiliation: Karlsruhe Institute of Technology, Germany
+  role: member
+- name: Hongkai Chen
+  affiliation: Arizona State University, USA
+  role: member
+- name: Paul Chung
+  affiliation: University of California, San Diego, USA
+  role: member
+- name: Muhammad Danish
+  affiliation: University of New Mexico, USA
+  role: member
+- name: Saurabh Deochake
+  affiliation: SentinelOne, Inc., USA
+  role: member
+- name: Janhavi Deshpande
+  affiliation: Salesforce Security, USA
+  role: member
+- name: Zheyun Feng
+  affiliation: University of New Hampshire, USA
+  role: member
+- name: Sanket Goutam
+  affiliation: Stony Brook University, USA
+  role: member
+- name: Keyan Guo
+  affiliation: University at Buffalo, USA
+  role: member
+- name: Ankit Gupta
+  affiliation: New York University, USA
+  role: member
+- name: Yifeng He
+  affiliation: University of California, Davis, USA
+  role: member
+- name: Mahdieh Heidaripour
+  affiliation: Augusta University, USA
+  role: member
+- name: Malvika Jadhav
+  affiliation: University of Florida, USA
+  role: member
+- name: Kathiresan Jayabalan
+  affiliation: IEEE, USA
+  role: member
+- name: Fujiao Ji
+  affiliation: University of Tennessee, Knoxville, USA
+  role: member
+- name: Qinhong Jiang
+  affiliation: Hong Kong Polytechnic University, China
+  role: member
+- name: Kunlin Li
+  affiliation: Hong Kong University of Science and Technology, China
+  role: member
+- name: Ying Li
+  affiliation: University of California, Los Angeles, USA
+  role: member
+- name: Zichuan Li
+  affiliation: University of Illinois, Urbana-Champaign, USA
+  role: member
+- name: Qishen Sam Liang
+  affiliation: University of Southern California, USA
+  role: member
+- name: Feng Luo
+  affiliation: Hong Kong Polytechnic University, China
+  role: member
+- name: Zhongkui Ma
+  affiliation: University of Queensland, Australia
+  role: member
+- name: Gnaneswara Marupilla
+  affiliation: Independent researcher
+  role: member
+- name: Khosro Moeini
+  affiliation: Boston University, USA
+  role: member
+- name: Akshata Kishore Moharir
+  affiliation: Microsoft, Inc., USA
+  role: member
+- name: Sidhant Narula
+  affiliation: Old Dominion University, USA
+  role: member
+- name: Bhakti Narvekar
+  affiliation: Walmart, Inc., USA
+  role: member
+- name: Steven Ngo
+  affiliation: University of California, Irvine, USA
+  role: member
+- name: Abanisenioluwa Orojo
+  affiliation: Baylor University, USA
+  role: member
+- name: Rupesh Prasad
+  affiliation: Analog Devices, Inc, USA
+  role: member
+- name: Mohammad Jamshir Qureshi
+  affiliation: Purdue University (USA)
+  role: member
+- name: Rishit Saiya
+  affiliation: PricewaterhouseCoopers, Inc., USA
+  role: member
+- name: Kunsheng Tang
+  affiliation: University of Science and Technology of China, China
+  role: member
+- name: Caner Tol
+  affiliation: Worcester Polytechnic Institute, USA
+  role: member
+- name: Lihua Wang
+  affiliation: University of New South Wales, Australia
+  role: member
+- name: Ruining Yang
+  affiliation: Stony Brook University, USA
+  role: member
+- name: Yuxiang Yang
+  affiliation: Tsinghua University, China
+  role: member
+- name: Junseung You
+  affiliation: Seoul National University, Korea
+  role: member
+- name: Jiongchi Yu
+  affiliation: Singapore Management University, Singapore
+  role: member
+- name: Bowen Zhang
+  affiliation: Hong Kong University of Science and Technology, China
+  role: member
+- name: Lupeng Zhang
+  affiliation: National Technical University, Singapore
+  role: member
+- name: Kunsong Zhao
+  affiliation: Hong Kong Polytechnic University, China
+  role: member

--- a/src/scrapers/scrape_committee_web.py
+++ b/src/scrapers/scrape_committee_web.py
@@ -8,6 +8,7 @@ Supported sources:
 - CHES website (ches.iacr.org)
 - PETS website (petsymposium.org)
 - ACSAC website (acsac.org)
+- IEEE S&P website (sp2026.ieee-security.org)
 """
 
 import logging
@@ -883,6 +884,131 @@ def scrape_acsac_committee(year, session=None, cache_only=False):
     return deduped if deduped else None
 
 
+SP_KNOWN_YEARS = (2026,)
+
+
+def _parse_table_rows(table):
+    """Return normalized cell text for each non-empty row in a table."""
+    rows = []
+    for tr in table.find_all("tr"):
+        cells = [re.sub(r"\s+", " ", cell.get_text(" ", strip=True)).strip() for cell in tr.find_all(["th", "td"])]
+        if any(cells):
+            rows.append(cells)
+    return rows
+
+
+def _scrape_sp_chairs_html(soup):
+    """Parse Artifact Evaluation Chairs from the S&P organizing committee table."""
+    chairs = []
+    table = None
+    for candidate in soup.find_all("table"):
+        for row in _parse_table_rows(candidate):
+            if row and row[0] == "Artifact Evaluation Chairs":
+                table = candidate
+                break
+        if table is not None:
+            break
+
+    if table is None:
+        return chairs
+
+    current_role = None
+    for row in _parse_table_rows(table):
+        if len(row) < 3:
+            continue
+        role_cell, name, affiliation = row[:3]
+        if role_cell:
+            current_role = role_cell
+        if current_role != "Artifact Evaluation Chairs":
+            continue
+        name = re.sub(r"\s+", " ", name).strip()
+        affiliation = re.sub(r"\s+", " ", affiliation).strip()
+        if name and len(name) > 1:
+            chairs.append({"name": name, "affiliation": affiliation, "role": "chair"})
+
+    return chairs
+
+
+def _scrape_sp_members_html(soup):
+    """Parse the S&P Artifact Evaluation Committee tables."""
+    members = []
+    heading = None
+    for h in soup.find_all(["h2", "h3", "h4"]):
+        txt = re.sub(r"\s+", " ", h.get_text(" ", strip=True)).strip()
+        if txt == "Artifact Evaluation Committee":
+            heading = h
+            break
+
+    if heading is None:
+        return members
+
+    for sib in heading.next_siblings:
+        if hasattr(sib, "name") and sib.name in ("h2", "h3"):
+            break
+        if not hasattr(sib, "find_all"):
+            continue
+        tables = [sib] if getattr(sib, "name", None) == "table" else sib.find_all("table")
+        for table in tables:
+            for row in _parse_table_rows(table):
+                if len(row) < 2:
+                    continue
+                name, affiliation = row[:2]
+                if name.lower() in {"name", "member"}:
+                    continue
+                name = re.sub(r"\s+", " ", name).strip()
+                affiliation = re.sub(r"\s+", " ", affiliation).strip()
+                if name and len(name) > 1:
+                    members.append({"name": name, "affiliation": affiliation, "role": "member"})
+
+    return members
+
+
+def scrape_sp_committee(year, session=None, cache_only=False):
+    """Scrape AE committee data from the IEEE S&P 2026 website.
+
+    The AEC members are listed on ``cfartifacts.html`` in separate cycle tables.
+    Artifact Evaluation Chairs are listed on ``index.html`` in the organizing
+    committee table.
+    """
+    if year not in SP_KNOWN_YEARS:
+        return None
+
+    base_url = f"https://sp{year}.ieee-security.org"
+    members_html = _cached_fetch(f"{base_url}/cfartifacts.html", session=session, cache_only=cache_only)
+    chairs_html = _cached_fetch(f"{base_url}/index.html", session=session, cache_only=cache_only)
+
+    members = []
+    chairs = []
+
+    if members_html is not None:
+        soup = BeautifulSoup(members_html, "html.parser")
+        members = _scrape_sp_members_html(soup)
+
+    if chairs_html is not None:
+        soup = BeautifulSoup(chairs_html, "html.parser")
+        chairs = _scrape_sp_chairs_html(soup)
+
+    if not members and not chairs:
+        return None
+
+    all_members = chairs + members
+    seen = set()
+    deduped = []
+    for member in all_members:
+        key = member["name"].lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(member)
+
+    if deduped:
+        chair_count = sum(1 for member in deduped if member["role"] == "chair")
+        member_count = len(deduped) - chair_count
+        logger.info("  IEEE S&P: Found %d members + %d chair(s) for sp%d", member_count, chair_count, year)
+
+    return deduped if deduped else None
+
+
 # ── HotCRP scraper ───────────────────────────────────────────────────────────
 
 # Maps (conference, year) to HotCRP PC-list URLs.
@@ -1037,6 +1163,8 @@ def get_alternative_committees(conferences_needed):
             committee = scrape_pets_committee(year, session=sess, cache_only=cache_only)
         elif conf == "acsac":
             committee = scrape_acsac_committee(year, session=sess, cache_only=cache_only)
+        elif conf == "sp":
+            committee = scrape_sp_committee(year, session=sess, cache_only=cache_only)
 
         # Try HotCRP (public pages, not blocked by SKIP_USENIX_SCRAPE)
         if not committee and (conf, year) in HOTCRP_URLS:
@@ -1096,6 +1224,7 @@ if __name__ == "__main__":
     parser.add_argument("--all-ches", action="store_true", help="Scrape all CHES years 2021-2025")
     parser.add_argument("--all-pets", action="store_true", help="Scrape all PETS years 2020-2025")
     parser.add_argument("--all-acsac", action="store_true", help="Scrape all ACSAC years 2020-2025")
+    parser.add_argument("--all-sp", action="store_true", help="Scrape IEEE S&P 2026 committee data")
     args = parser.parse_args()
 
     if args.all_usenix:
@@ -1126,6 +1255,14 @@ if __name__ == "__main__":
                 logger.info(f"acsac{y}: {len(committee)} members")
             else:
                 logger.info(f"acsac{y}: not found")
+    elif args.all_sp:
+        sess = _get_session()
+        for y in SP_KNOWN_YEARS:
+            committee = scrape_sp_committee(y, session=sess)
+            if committee:
+                logger.info(f"sp{y}: {len(committee)} members")
+            else:
+                logger.info(f"sp{y}: not found")
     elif args.conference and args.year:
         conf = args.conference.lower()
         if conf in USENIX_CONF_SLUGS:
@@ -1136,6 +1273,8 @@ if __name__ == "__main__":
             result = scrape_pets_committee(args.year)
         elif conf == "acsac":
             result = scrape_acsac_committee(args.year)
+        elif conf == "sp":
+            result = scrape_sp_committee(args.year)
         else:
             logger.info(f"Unknown conference: {conf}")
             sys.exit(1)

--- a/tests/scrapers/test_scrape_sp_committee.py
+++ b/tests/scrapers/test_scrape_sp_committee.py
@@ -1,0 +1,80 @@
+"""Tests for the IEEE S&P 2026 committee scraper."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.scrapers.scrape_committee_web import scrape_sp_committee
+from src.utils.io.cache import _MISSING
+
+
+@pytest.fixture(autouse=True)
+def _no_disk_cache():
+    """Prevent disk cache from interfering between tests."""
+    with (
+        patch("src.utils.io.cache.read_cache", return_value=_MISSING),
+        patch("src.utils.io.cache.write_cache"),
+    ):
+        yield
+
+
+def _mock_session(member_html: str, chair_html: str):
+    """Build a mock session that returns different responses per URL."""
+    session = MagicMock()
+
+    def fake_get(url, **kwargs):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.raise_for_status = MagicMock()
+        if url.endswith("cfartifacts.html"):
+            resp.text = member_html
+            resp.json.return_value = json.loads("{}")
+        elif url.endswith("index.html"):
+            resp.text = chair_html
+            resp.json.return_value = json.loads("{}")
+        else:
+            resp.text = ""
+            resp.json.return_value = json.loads("{}")
+        return resp
+
+    session.get = fake_get
+    return session
+
+
+def test_sp_2026_members_and_chairs():
+    member_html = """
+    <h2>Artifact Evaluation Committee</h2>
+    <h4>Cycle 1</h4>
+    <table>
+      <tr><td>Alice A</td><td>North Carolina State University</td></tr>
+      <tr><td>Bob B</td><td>University of California Irvine</td></tr>
+    </table>
+    <h4>Cycle 2</h4>
+    <table>
+      <tr><td>Alice A</td><td>North Carolina State University, USA</td></tr>
+      <tr><td>Carol C</td><td>University of Wisconsin-Madison</td></tr>
+    </table>
+    """
+    chair_html = """
+    <table>
+      <tr><td>General Chair</td><td>Alina Oprea</td><td>Northeastern University</td></tr>
+      <tr><td>Artifact Evaluation Chairs</td><td>Jelena Mirkovic</td><td>University of Southern California</td></tr>
+      <tr><td></td><td>Manuel Egele</td><td>Boston University</td></tr>
+      <tr><td>Web Chair</td><td>Andreas Brüggemann</td><td>TU Darmstadt</td></tr>
+    </table>
+    """
+    session = _mock_session(member_html, chair_html)
+
+    result = scrape_sp_committee(2026, session=session)
+
+    assert result is not None
+    names = {entry["name"] for entry in result}
+    assert names == {"Alice A", "Bob B", "Carol C", "Jelena Mirkovic", "Manuel Egele"}
+
+    chairs = [entry for entry in result if entry["role"] == "chair"]
+    assert len(chairs) == 2
+    assert {entry["name"] for entry in chairs} == {"Jelena Mirkovic", "Manuel Egele"}
+
+    members = [entry for entry in result if entry["role"] == "member"]
+    assert len(members) == 3


### PR DESCRIPTION
Adds support for scraping IEEE S&P 2026 committee data, including year-aware URL handling and a regression test for chair/member extraction.

Also updates `data/local_committees.yaml` with the generated S&P 2026 fallback entry so the pipeline can continue to operate offline or when upstream pages are unavailable.