### PR TITLE
Use structured Zenodo repo metadata in artifact URLs

### DIFF
--- a/src/generators/output/generate_statistics.py
+++ b/src/generators/output/generate_statistics.py
@@ -26,7 +26,7 @@ from src.scrapers.acm_scrape import (
     to_pipeline_format as acm_to_pipeline_format,
 )
 from src.scrapers.parse_results_md import get_ae_results
-from src.scrapers.repo_utils import get_conferences_from_prefix
+from src.scrapers.repo_utils import cached_figshare_stats, cached_zenodo_stats, get_conferences_from_prefix
 from src.scrapers.usenix_scrape import scrape_conference_year, to_pipeline_format
 from src.utils.io.io import save_validated_json, save_yaml
 from src.utils.normalization.conference import CONF_DISPLAY_NAMES, ensure_conference_pages
@@ -181,6 +181,20 @@ def _collect_artifact_urls(artifact: dict) -> list[str]:
         extra_url = artifact.get(url_key, "")
         if extra_url:
             urls.append(extra_url)
+
+    # Zenodo/Figshare records can link to the actual code repository in their
+    # own metadata. Fold those discovered repos into artifact_urls so search and
+    # other downstream exports see the same canonical artifact locations as
+    # repo_stats.
+    for source_url in list(urls):
+        stats = None
+        if "zenodo" in source_url:
+            stats = cached_zenodo_stats(source_url)
+        elif "figshare" in source_url:
+            stats = cached_figshare_stats(source_url)
+        if isinstance(stats, dict):
+            urls.extend(stats.get("linked_github_urls", []))
+
     # Deduplicate while preserving order
     seen: set[str] = set()
     deduped: list[str] = []

--- a/src/scrapers/repo_utils.py
+++ b/src/scrapers/repo_utils.py
@@ -269,13 +269,10 @@ def _extract_github_urls_from_zenodo(record: dict) -> list[str]:
 
     1. ``metadata.related_identifiers`` – structured links.
     2. ``metadata.alternate_identifiers`` – alternate structured links.
-    3. ``metadata.description`` – free-text HTML/Markdown.
-    4. ``metadata.notes`` – free-text additional notes.
+    3. ``metadata.custom`` / ``metadata.custom_fields`` – structured custom fields.
 
     Returns deduplicated base repo URLs (``https://github.com/owner/repo``).
     """
-    import re as _re
-
     urls: list[str] = []
     seen: set[str] = set()
     meta = record.get("metadata", {})
@@ -283,7 +280,7 @@ def _extract_github_urls_from_zenodo(record: dict) -> list[str]:
     # 1. related_identifiers
     for ri in meta.get("related_identifiers", []):
         ident = ri.get("identifier", "")
-        if "github.com/" not in ident:
+        if "github.com" not in ident:
             continue
         base = _normalise_github_repo_url(ident)
         if base and base not in seen:
@@ -293,17 +290,22 @@ def _extract_github_urls_from_zenodo(record: dict) -> list[str]:
     # 2. alternate_identifiers
     for ai in meta.get("alternate_identifiers", []):
         ident = ai.get("identifier", "")
-        if "github.com/" not in ident:
+        if "github.com" not in ident:
             continue
         base = _normalise_github_repo_url(ident)
         if base and base not in seen:
             seen.add(base)
             urls.append(base)
 
-    # 3. description (free-text HTML)
-    for text in (meta.get("description", ""), meta.get("notes", "")):
-        for match in _re.findall(r"https?://github\.com/[^\s<\"'&;)]+", text):
-            base = _normalise_github_repo_url(match.rstrip(".,;:)"))
+    # 3. structured custom fields
+    for custom_key in ("custom", "custom_fields"):
+        custom = meta.get(custom_key, {})
+        if not isinstance(custom, dict):
+            continue
+        for value in custom.values():
+            if not isinstance(value, str) or "github.com" not in value:
+                continue
+            base = _normalise_github_repo_url(value)
             if base and base not in seen:
                 seen.add(base)
                 urls.append(base)
@@ -357,12 +359,19 @@ def _extract_github_urls_from_figshare(record: dict) -> list[str]:
 def _normalise_github_repo_url(url: str) -> str | None:
     """Reduce a GitHub URL to ``https://github.com/owner/repo``.
 
-    Handles tree/blob suffixes, .git extensions, and query strings.
+    Handles tree/blob suffixes, .git extensions, query strings, and SSH clone
+    URLs like ``git@github.com:owner/repo.git``.
     Returns *None* for URLs that don't look like a valid owner/repo path.
     """
     import re
 
     url = url.split("?")[0].split("#")[0].rstrip("/")
+    ssh_match = re.match(r"git@github\.com:([^/]+)/([^/]+)", url)
+    if ssh_match:
+        repo = ssh_match.group(2)
+        if repo.endswith(".git"):
+            repo = repo[:-4]
+        return f"https://github.com/{ssh_match.group(1)}/{repo}"
     # Strip .git suffix
     if url.endswith(".git"):
         url = url[:-4]
@@ -377,9 +386,12 @@ def cached_zenodo_stats(url: str, ttl: int = CACHE_TTL_STATS) -> dict[str, Any]:
     cached = _read_cache(CACHE_DIR, url, ttl=ttl, namespace="zenodo_stats")
     if cached is not _MISSING:
         # Stale entries cached before linked_github_urls extraction was
-        # added lack the key entirely.  Force a re-fetch so we discover
-        # GitHub repos linked from Zenodo metadata.
-        if isinstance(cached, dict) and "linked_github_urls" not in cached:
+        # added, or before SSH clone URLs were parsed, lack the current
+        # extraction marker. Force a re-fetch so we discover GitHub repos
+        # linked from Zenodo metadata consistently.
+        if isinstance(cached, dict) and (
+            "linked_github_urls" not in cached or cached.get("linked_github_urls_version", 0) < 3
+        ):
             pass  # fall through to re-fetch
         else:
             return cached
@@ -406,6 +418,7 @@ def cached_zenodo_stats(url: str, ttl: int = CACHE_TTL_STATS) -> dict[str, Any]:
                 # Always store the key (even empty) so the cache can
                 # distinguish "checked, no links" from "never checked".
                 result["linked_github_urls"] = _extract_github_urls_from_zenodo(record)
+                result["linked_github_urls_version"] = 3
                 break
             if resp.status_code == 429:
                 retry_after = int(resp.headers.get("Retry-After", 0))

--- a/tests/generators/test_generate_statistics.py
+++ b/tests/generators/test_generate_statistics.py
@@ -1,5 +1,6 @@
 """Tests for generate_statistics — pure helper functions."""
 
+from src.generators.output import generate_statistics as generate_statistics_module
 from src.generators.output.generate_statistics import (
     _build_artifact_entry,
     _collect_artifact_urls,
@@ -106,6 +107,45 @@ class TestCollectArtifactUrls:
     def test_skips_empty_strings(self):
         art = {"repository_url": "", "artifact_url": ""}
         assert _collect_artifact_urls(art) == []
+
+    def test_includes_linked_github_urls_from_zenodo(self, monkeypatch):
+        monkeypatch.setattr(
+            generate_statistics_module,
+            "cached_zenodo_stats",
+            lambda url: {
+                "linked_github_urls": [
+                    "https://github.com/zju-muslab/AudioHijack",
+                    "https://github.com/facebookresearch/fairseq",
+                ]
+            },
+        )
+        monkeypatch.setattr(generate_statistics_module, "cached_figshare_stats", lambda url: {})
+
+        art = {"artifact_url": "https://zenodo.org/records/19309781"}
+
+        assert _collect_artifact_urls(art) == [
+            "https://zenodo.org/records/19309781",
+            "https://github.com/zju-muslab/AudioHijack",
+            "https://github.com/facebookresearch/fairseq",
+        ]
+
+    def test_deduplicates_discovered_repo_urls(self, monkeypatch):
+        monkeypatch.setattr(
+            generate_statistics_module,
+            "cached_zenodo_stats",
+            lambda url: {"linked_github_urls": ["https://github.com/zju-muslab/AudioHijack"]},
+        )
+        monkeypatch.setattr(generate_statistics_module, "cached_figshare_stats", lambda url: {})
+
+        art = {
+            "repository_url": "https://github.com/zju-muslab/AudioHijack",
+            "artifact_url": "https://zenodo.org/records/19309781",
+        }
+
+        assert _collect_artifact_urls(art) == [
+            "https://github.com/zju-muslab/AudioHijack",
+            "https://zenodo.org/records/19309781",
+        ]
 
 
 class TestBuildArtifactEntry:

--- a/tests/scrapers/test_repo_utils.py
+++ b/tests/scrapers/test_repo_utils.py
@@ -176,9 +176,7 @@ class TestCachedZenodoStats:
                 "stats": {"unique_views": 10, "unique_downloads": 5},
                 "updated": "2024-06-01",
                 "created": "2024-01-01",
-                "metadata": {
-                    "custom": {"code:codeRepository": "https://github.com/zju-muslab/AudioHijack"}
-                },
+                "metadata": {"custom": {"code:codeRepository": "https://github.com/zju-muslab/AudioHijack"}},
             },
         )
         stats = repo_utils.cached_zenodo_stats("https://zenodo.org/records/19309781")

--- a/tests/scrapers/test_repo_utils.py
+++ b/tests/scrapers/test_repo_utils.py
@@ -169,6 +169,21 @@ class TestCachedZenodoStats:
         stats = repo_utils.cached_zenodo_stats("https://zenodo.org/records/12345")
         assert stats["linked_github_urls"] == ["https://github.com/owner/repo"]
 
+    def test_extracts_linked_github_urls_from_custom_field(self, mock_session):
+        mock_session.get.return_value = _fake_response(
+            200,
+            json_data={
+                "stats": {"unique_views": 10, "unique_downloads": 5},
+                "updated": "2024-06-01",
+                "created": "2024-01-01",
+                "metadata": {
+                    "custom": {"code:codeRepository": "https://github.com/zju-muslab/AudioHijack"}
+                },
+            },
+        )
+        stats = repo_utils.cached_zenodo_stats("https://zenodo.org/records/19309781")
+        assert stats["linked_github_urls"] == ["https://github.com/zju-muslab/AudioHijack"]
+
     def test_no_linked_github_urls_stores_empty_list(self, mock_session):
         mock_session.get.return_value = _fake_response(
             200,
@@ -243,6 +258,12 @@ class TestCachedFigshareStats:
 
 
 class TestNormaliseGithubRepoUrl:
+    def test_normalises_ssh_clone_url(self):
+        assert (
+            repo_utils._normalise_github_repo_url("git@github.com:zju-muslab/AudioHijack.git")
+            == "https://github.com/zju-muslab/AudioHijack"
+        )
+
     def test_strips_tree_suffix(self):
         assert (
             repo_utils._normalise_github_repo_url("https://github.com/owner/repo/tree/v1.0")
@@ -301,41 +322,48 @@ class TestExtractGithubUrlsFromZenodo:
     def test_empty_when_no_metadata(self):
         assert repo_utils._extract_github_urls_from_zenodo({}) == []
 
-    def test_extracts_from_description(self):
+    def test_extracts_from_custom(self):
         record = {
             "metadata": {
-                "description": '<p>Code at <a href="https://github.com/alice/project">GitHub</a>.</p>',
+                "custom": {
+                    "code:codeRepository": "https://github.com/alice/project",
+                },
             }
         }
         assert repo_utils._extract_github_urls_from_zenodo(record) == ["https://github.com/alice/project"]
 
-    def test_description_deduplicates_with_related(self):
+    def test_custom_deduplicates_with_related(self):
         record = {
             "metadata": {
                 "related_identifiers": [
                     {"identifier": "https://github.com/alice/project/tree/v1"},
                 ],
-                "description": "See https://github.com/alice/project for code.",
+                "custom": {"code:codeRepository": "https://github.com/alice/project"},
             }
         }
         # Should not duplicate the same repo
         assert repo_utils._extract_github_urls_from_zenodo(record) == ["https://github.com/alice/project"]
 
-    def test_description_trailing_punctuation(self):
+    def test_extracts_from_custom_fields(self):
         record = {
             "metadata": {
-                "description": "Code: https://github.com/hanshanley/tracking-takes.",
+                "custom_fields": {
+                    "code:codeRepository": "https://github.com/hanshanley/tracking-takes",
+                },
             }
         }
         assert repo_utils._extract_github_urls_from_zenodo(record) == ["https://github.com/hanshanley/tracking-takes"]
 
-    def test_extracts_from_notes(self):
+    def test_ignores_non_github_custom_fields(self):
         record = {
             "metadata": {
-                "notes": "Source code: https://github.com/bob/tool",
+                "custom": {
+                    "dwc:scientificName": "not a repo",
+                    "code:buildInstructions": "see README",
+                },
             }
         }
-        assert repo_utils._extract_github_urls_from_zenodo(record) == ["https://github.com/bob/tool"]
+        assert repo_utils._extract_github_urls_from_zenodo(record) == []
 
     def test_extracts_from_alternate_identifiers(self):
         record = {
@@ -356,8 +384,7 @@ class TestExtractGithubUrlsFromZenodo:
                 "alternate_identifiers": [
                     {"identifier": "https://github.com/x/y"},
                 ],
-                "description": "See https://github.com/x/y for code.",
-                "notes": "Also at https://github.com/x/y",
+                "custom": {"code:codeRepository": "https://github.com/x/y"},
             }
         }
         assert repo_utils._extract_github_urls_from_zenodo(record) == ["https://github.com/x/y"]


### PR DESCRIPTION
This updates Zenodo repository discovery so `artifact_urls` only picks up the primary repository from structured Zenodo metadata instead of incidental dependency links.

Summary:
- add Zenodo-derived repository URLs into the existing `artifact_urls` export path
- extract Zenodo repository links from structured metadata fields (`related_identifiers`, `alternate_identifiers`, `custom`, `custom_fields`)
- stop relying on Zenodo free-text description/notes for repository extraction
- refresh cached Zenodo metadata when the extraction version changes
- add focused tests for generator behavior and Zenodo metadata extraction

Validation:
- `pytest tests/generators/test_generate_statistics.py tests/scrapers/test_repo_utils.py -q`
- regenerated staged outputs and verified the target paper now has:
  - `https://zenodo.org/records/19309781`
  - `https://github.com/zju-muslab/AudioHijack`

Why:
The affected paper's Zenodo record exposes the primary code repository in structured metadata (`code:codeRepository`). Repo stats and search/export data should use that canonical source and avoid dependency repos such as `fairseq` or `SpeechGPT`.