### PR TITLE
fix: dispatch update-stats to reprodb.github.io repo

### DIFF
--- a/.github/workflows/dblp-author-analysis.yml
+++ b/.github/workflows/dblp-author-analysis.yml
@@ -183,7 +183,7 @@ jobs:
 
       - name: Trigger statistics update
         if: steps.check_changes.outputs.changed == 'true' && github.repository_owner == 'ReproDB'
-        run: gh workflow run update-stats.yml
+        run: gh workflow run update-stats.yml -R ${{ github.repository_owner }}/reprodb.github.io
         env:
           GH_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}
       


### PR DESCRIPTION
Fixes 403 error in the author analysis workflow.

`gh workflow run update-stats.yml` was dispatching against the current repo (`reprodb-pipeline`) instead of `reprodb.github.io` where `update-stats.yml` lives. Added `-R ${{ github.repository_owner }}/reprodb.github.io` to target the correct repository.