### PR TITLE
fix: handle malformed paper_url values in artifacts

### DIFF
--- a/src/models/artifacts/artifacts.py
+++ b/src/models/artifacts/artifacts.py
@@ -92,6 +92,17 @@ class Artifact(BaseModel):
             return str(v).lower()
         return v  # type: ignore[return-value]
 
+    @field_validator("paper_url", "appendix_url", mode="before")
+    @classmethod
+    def _normalize_optional_url(cls, v: object) -> str | None:
+        """Drop malformed URL-like values instead of failing whole artifact validation."""
+        if v is None:
+            return None
+        if isinstance(v, str):
+            normalized = v.strip()
+            return normalized or None
+        return None
+
     model_config = {"extra": "forbid"}
 
 

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -404,6 +404,10 @@ class TestArtifactArtifinderUrls:
         art = self._make(artifinder_urls=["https://github.com/found/repo"])
         assert art.artifinder_urls == ["https://github.com/found/repo"]
 
+    def test_non_string_paper_url_is_normalized_to_none(self):
+        art = self._make(paper_url=54)
+        assert art.paper_url is None
+
 
 # ── Paper (paper_index) ───────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- normalize non-string optional URL fields (`paper_url`, `appendix_url`) to `null` in `Artifact` model validation
- avoid hard pipeline failure when malformed source rows contain non-string URL values
- add regression test for numeric `paper_url` input

## Validation
- `python3 -m pytest tests/models/test_models.py -q` (43 passed)

This PR includes only the two files changed for this fix.