### PR TITLE
fix: dispatch update-stats using GITHUB_TOKEN with actions:write

### DIFF
--- a/.github/workflows/dblp-author-analysis.yml
+++ b/.github/workflows/dblp-author-analysis.yml
@@ -15,6 +15,10 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   author-analysis:
     runs-on: ubuntu-latest
@@ -183,9 +187,9 @@ jobs:
 
       - name: Trigger statistics update
         if: steps.check_changes.outputs.changed == 'true' && github.repository_owner == 'ReproDB'
-        run: gh workflow run update-stats.yml -R ${{ github.repository_owner }}/reprodb.github.io
+        run: gh workflow run update-stats.yml -R ${{ github.repository_owner }}/reprodb-pipeline
         env:
-          GH_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Summary
         run: |


### PR DESCRIPTION
Fixes the remaining 404 from the previous fix (PR #21).

**Root cause:** `update-stats.yml` lives in `reprodb-pipeline`, not `reprodb.github.io`. PR #21 incorrectly redirected the dispatch to `reprodb.github.io` → HTTP 404.

**This fix:**
- Targets `reprodb-pipeline` (correct repo)  
- Switches from `CROSS_REPO_TOKEN` (lacks `workflow` scope) to `GITHUB_TOKEN`
- Adds `permissions.actions: write` so `GITHUB_TOKEN` can dispatch `workflow_dispatch` events in the same repo