### PR TITLE
fix: normalize malformed ACSAC artifact URLs

### DIFF
--- a/src/scrapers/parse_results_md.py
+++ b/src/scrapers/parse_results_md.py
@@ -24,6 +24,58 @@ logger = logging.getLogger(__name__)
 RESULTS_FILENAMES = ["results.md", "result.md"]
 
 
+def _extract_http_urls(raw: str) -> list[str]:
+    """Extract one or more HTTP(S) URLs from a raw scalar string.
+
+    Some conference sources place multiple URLs in one YAML scalar separated by
+    spaces. This helper splits them while keeping valid URL characters.
+    """
+    if not isinstance(raw, str):
+        return []
+    urls = re.findall(r"https?://[^\s]+", raw)
+    # Strip common trailing punctuation from surrounding prose/markdown.
+    return [u.rstrip(").,;>") for u in urls]
+
+
+def _normalize_yaml_artifact_urls(artifact: dict) -> dict:
+    """Normalize URL fields in one artifact dict.
+
+    Ensures malformed space-separated URL scalars are represented as canonical
+    ``artifact_urls`` lists while keeping ``artifact_url`` for compatibility.
+    """
+    if not isinstance(artifact, dict):
+        return artifact
+
+    out = dict(artifact)
+
+    # Start with any existing list-style URLs.
+    canonical_urls: list[str] = []
+    existing = out.get("artifact_urls", [])
+    if isinstance(existing, list):
+        for item in existing:
+            if isinstance(item, str):
+                canonical_urls.extend(_extract_http_urls(item))
+
+    # Merge legacy single-value field (which may contain multiple URLs).
+    legacy = out.get("artifact_url", "")
+    if isinstance(legacy, str):
+        canonical_urls.extend(_extract_http_urls(legacy))
+
+    # Deduplicate while preserving order.
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for u in canonical_urls:
+        if u and u not in seen:
+            seen.add(u)
+            deduped.append(u)
+
+    if deduped:
+        out["artifact_urls"] = deduped
+        out["artifact_url"] = deduped[0]
+
+    return out
+
+
 def parse_html_results(content):
     """
     Parse HTML-table-based results pages (used by OSDI, ATC, etc.).
@@ -224,14 +276,19 @@ def get_ae_results(conference_regex, prefix):
             try:
                 parsed_content = yaml.safe_load(yaml_part)
                 if parsed_content and "artifacts" in parsed_content:
-                    parsed_results[conf_year] = parsed_content["artifacts"]
+                    artifacts = parsed_content["artifacts"]
+                    if isinstance(artifacts, list):
+                        artifacts = [_normalize_yaml_artifact_urls(a) for a in artifacts]
+                    parsed_results[conf_year] = artifacts
                     logger.info(f"  {conf_year}: parsed {len(parsed_content['artifacts'])} artifacts (YAML)")
                     continue
                 if parsed_content and "issues" in parsed_content:
                     # PETS-style: artifacts nested under issues list
                     all_artifacts = []
                     for issue in parsed_content["issues"]:
-                        all_artifacts.extend(issue.get("artifacts", []))
+                        raw_artifacts = issue.get("artifacts", [])
+                        if isinstance(raw_artifacts, list):
+                            all_artifacts.extend(_normalize_yaml_artifact_urls(a) for a in raw_artifacts)
                     if all_artifacts:
                         parsed_results[conf_year] = all_artifacts
                         logger.info(f"  {conf_year}: parsed {len(all_artifacts)} artifacts (YAML/issues)")

--- a/tests/scrapers/test_parse_results_md.py
+++ b/tests/scrapers/test_parse_results_md.py
@@ -1,6 +1,10 @@
-"""Tests for src/scrapers/parse_results_md — HTML and markdown table parsers."""
+"""Tests for src/scrapers/parse_results_md — HTML/markdown and YAML normalization."""
 
-from src.scrapers.parse_results_md import parse_html_results, parse_markdown_table_results
+from src.scrapers.parse_results_md import (
+        _normalize_yaml_artifact_urls,
+        parse_html_results,
+        parse_markdown_table_results,
+)
 
 
 class TestParseHtmlResults:
@@ -116,3 +120,36 @@ class TestParseMarkdownTableResults:
         md = "| No Link Here | <span>AVAILABLE</span> | |"
         result = parse_markdown_table_results(md)
         assert len(result) == 0
+
+class TestYamlArtifactUrlNormalization:
+    def test_splits_space_separated_artifact_url(self):
+        artifact = {
+            "title": "Measuring Popularity Of Cryptographic Libraries In Internet-wide Scans",
+            "artifact_url": "https://crocs.fi.muni.cz/public/papers/acsac2017 https://github.com/crocs-muni/classifyRSAkey",
+        }
+
+        normalized = _normalize_yaml_artifact_urls(artifact)
+
+        assert normalized["artifact_url"] == "https://crocs.fi.muni.cz/public/papers/acsac2017"
+        assert normalized["artifact_urls"] == [
+            "https://crocs.fi.muni.cz/public/papers/acsac2017",
+            "https://github.com/crocs-muni/classifyRSAkey",
+        ]
+
+    def test_keeps_existing_artifact_urls_and_deduplicates(self):
+        artifact = {
+            "artifact_urls": [
+                "https://github.com/example/repo",
+                "https://doi.org/10.5281/zenodo.123",
+            ],
+            "artifact_url": "https://github.com/example/repo https://gitlab.com/example/repo",
+        }
+
+        normalized = _normalize_yaml_artifact_urls(artifact)
+
+        assert normalized["artifact_urls"] == [
+            "https://github.com/example/repo",
+            "https://doi.org/10.5281/zenodo.123",
+            "https://gitlab.com/example/repo",
+        ]
+        assert normalized["artifact_url"] == "https://github.com/example/repo"

--- a/tests/scrapers/test_parse_results_md.py
+++ b/tests/scrapers/test_parse_results_md.py
@@ -1,9 +1,9 @@
 """Tests for src/scrapers/parse_results_md — HTML/markdown and YAML normalization."""
 
 from src.scrapers.parse_results_md import (
-        _normalize_yaml_artifact_urls,
-        parse_html_results,
-        parse_markdown_table_results,
+    _normalize_yaml_artifact_urls,
+    parse_html_results,
+    parse_markdown_table_results,
 )
 
 
@@ -120,6 +120,7 @@ class TestParseMarkdownTableResults:
         md = "| No Link Here | <span>AVAILABLE</span> | |"
         result = parse_markdown_table_results(md)
         assert len(result) == 0
+
 
 class TestYamlArtifactUrlNormalization:
     def test_splits_space_separated_artifact_url(self):


### PR DESCRIPTION
## Summary
Fix YAML result parsing to handle malformed artifact URL fields that contain multiple URLs in a single space-separated scalar (observed in ACSAC 2017 entries).

## What changed
- Added URL extraction helper that splits HTTP(S) URLs from raw scalar fields.
- Added YAML artifact URL normalization that:
  - builds canonical `artifact_urls` from both `artifact_urls` and legacy `artifact_url`
  - deduplicates while preserving order
  - preserves backward compatibility by keeping `artifact_url` as the first URL
- Applied normalization in both YAML parse paths:
  - top-level `artifacts`
  - nested `issues[].artifacts` (PETS-style)
- Added regression tests for:
  - space-separated URLs in `artifact_url`
  - merging/deduplication with existing `artifact_urls`

## Validation
- `pytest -q tests/scrapers/test_parse_results_md.py`
- Result: 15 passed

## Why this is needed
Some ACSAC instances store multiple artifact links in one field separated by spaces, which previously flowed into malformed single URL values in downstream data. This patch normalizes those entries at ingest time.